### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ and their breakdown by regions and provinces.
 
 The [geographic projection](https://github.com/d3/d3-geo) used is WGS84.
 
-The limits are released both in [topojson](https://github.com/topojson/topojson) with a high simplification rate (5%),
+The limits are released both in [topojson](https://github.com/topojson/topojson) with a high simplification rate (20%),
 and the non-simplified [geojson](https://geojson.org/) format.
 
 As administrative limits change continuously, the files are upgraded periodically, and refer to the **latest** administrative subdivisions, as published by [ISTAT](https://www.istat.it/) in [this permalink](https://www.istat.it/it/archivio/222527) (hoping it's actually a **permalink**).
@@ -15,18 +15,18 @@ Historical versions, year by year, are published as tags, currently only 2019 an
 The master branch currently contains limits as of February 2021.
 
 # Attribution
-The original administrative limits data are copirighted by ISTAT, that releases them under the CC-BY license.
+The original administrative limits data are copyrighted by ISTAT, that releases them under the CC-BY license.
 The data generated and published here are released under the same CC-BY license.
 
 # Geojson files
-This files are **not simplified**, contain a large number of vectors, and can only contain one layer.
+These files are **not simplified**, contain a large number of vectors, and can only contain one layer.
 They are compatible with almost all visualisers and applications, and can be used to integrate geographic information,
 almost as ubiquitously as shp files.
 
 The following files are available:
-- [geojson/limits_IT_municipalities.geojson](https://github.com/openpolis/geojson-italy/blob/master/geojson/limits_IT_municipalities.geojson) - all italian municipalities, ~40MB
-- [geojson/limits_IT_provinces.geojson](https://github.com/openpolis/geojson-italy/blob/master/geojson/limits_IT_provinces.geojson) - all italian provinces
-- [geojson/limits_IT_regions.geojson](https://github.com/openpolis/geojson-italy/blob/master/geojson/limits_IT_regions.geojson) - all italian regions
+- [geojson/limits_IT_municipalities.geojson](https://github.com/openpolis/geojson-italy/blob/master/geojson/limits_IT_municipalities.geojson) - all Italian municipalities, ~40MB
+- [geojson/limits_IT_provinces.geojson](https://github.com/openpolis/geojson-italy/blob/master/geojson/limits_IT_provinces.geojson) - all Italian provinces
+- [geojson/limits_IT_regions.geojson](https://github.com/openpolis/geojson-italy/blob/master/geojson/limits_IT_regions.geojson) - all Italian regions
 - geojson/limits_R_{code}_municipalities.geojson - all municipalities in a region (R is the ISTAT numerical code of the region, ex: [geojson/limits_R_12_municipalities.geojson](https://github.com/openpolis/geojson-italy/blob/master/geojson/limits_R_12_municipalities.geojson) - Lazio region)
 - geojson/limits_P_{code}_municipalities.geojson - all munitipalities in a province (P is the ISTAT numerical code of the province, ex: [geojson/limits_P_58_municipalities.geojson](https://github.com/openpolis/geojson-italy/blob/master/geojson/limits_P_58_municipalities.geojson) - Rome province)
 
@@ -38,9 +38,9 @@ These files are **simplified**, **smaller**, but **less precise**, and contains 
 
 The following `topojson` files are available:
 - [topojson/limits_IT_all.topo.json](https://github.com/openpolis/geojson-italy/blob/master/topojson/limits_IT_all.topo.json) - all municipalities, provinces and regions (3 layers), ~4MB
-- [topojson/limits_IT_municipalities.topo.json](https://github.com/openpolis/geojson-italy/blob/master/topojson/limits_IT_municipalities.topo.json) - all italian municipalities (1 layer), ~4MB
-- [topojson/limits_IT_provinces.topo.json](https://github.com/openpolis/geojson-italy/blob/master/topojson/limits_IT_provinces.topo.json) - all italian provinces (1 layer)
-- [topojson/limits_IT_regions.topo.json](https://github.com/openpolis/geojson-italy/blob/master/topojson/limits_IT_regions.topo.json) - all italian regions (1 layer)
+- [topojson/limits_IT_municipalities.topo.json](https://github.com/openpolis/geojson-italy/blob/master/topojson/limits_IT_municipalities.topo.json) - all Italian municipalities (1 layer), ~4MB
+- [topojson/limits_IT_provinces.topo.json](https://github.com/openpolis/geojson-italy/blob/master/topojson/limits_IT_provinces.topo.json) - all Italian provinces (1 layer)
+- [topojson/limits_IT_regions.topo.json](https://github.com/openpolis/geojson-italy/blob/master/topojson/limits_IT_regions.topo.json) - all Italian regions (1 layer)
 - topojson/limits_R_{code}_municipalities.topo.json - all municipalities in a region (R is the ISTAT numerical code of the region, for ex: [topojson/limits_R_12_municipalities.topo.json](https://github.com/openpolis/geojson-italy/blob/master/topojson/limits_R_12_municipalities.topo.json) - Lazio region)
 - topojson/limits_P_{code}_municipalities.topo.json - all munitipalities in a province (P is the ISTAT numerical code of the province, for ex: [topojson/limits_P_58_municipalities.topo.json](https://github.com/openpolis/geojson-italy/blob/master/topojson/limits_P_58_municipalities.topo.json) - Rome province)
 
@@ -49,7 +49,7 @@ Please consider that maps preview for topojson data are not available on github.
 # Metadata
 Each geographic area has the following metadata:
 - `name` (M) - the name of the municipality
-- `com_catasto_code` (M) - the cadraste code (H501)
+- `com_catasto_code` (M) - the cadaster code (H501)
 - `com_istat_code` (M) - the ISTAT code, as text (zero-padded)
 - `com_istat_code_num` (M) - the ISTAT code, as integer
 - `op_id` (M) - the openpolis ID (for integration with legacy OP data)


### PR DESCRIPTION
I assumed British English here.
If we want American English we need to write

- `visualizers` instead of `visualisers`
- `cadastre` instead of `cadaster`